### PR TITLE
docs: fix typo in nuxtjs composition package name

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -48,7 +48,7 @@ If you are using [**Nuxt**](https://nuxtjs.org/), this **package** has a specifi
 
 It is called [**nuxt-use-motion**](https://github.com/Tahul/nuxt-use-motion).
 
-You **must** have [**@nuxt/composition-api**](https://composition-api.nuxtjs.org/) setup in your **project** in order to make this **work**.
+You **must** have [**@nuxtjs/composition-api**](https://composition-api.nuxtjs.org/) setup in your **project** in order to make this **work**.
 
 Once you **installed** it, just add `nuxt-use-motion` to your project:
 


### PR DESCRIPTION
The npm organization name for nuxt is `nuxtjs`, my first action was to copy the name from the docs and paste in with a yarn add. This actions results in a package not found error, so my suggestion is to use the proper organization name so copy and pasting the package name will result in installing the proper package.