### PR TITLE
make visibilityHooks animation work if element is visible initially

### DIFF
--- a/src/directive/index.ts
+++ b/src/directive/index.ts
@@ -59,7 +59,7 @@ export const directive = (
 
   return {
     // Vue 3 Directive Hooks
-    created: register,
+    mounted: register,
     unmounted: unregister,
     // Vue 2 Directive Hooks
     // For Nuxt & Vue 2 compatibility

--- a/src/features/visibilityHooks.ts
+++ b/src/features/visibilityHooks.ts
@@ -1,5 +1,5 @@
 import { noop, useIntersectionObserver } from '@vueuse/core'
-import { unref } from 'vue-demi'
+import { unref, nextTick } from 'vue-demi'
 import { MotionInstance, MotionVariants } from '../types'
 
 export function registerVisibilityHooks<T extends MotionVariants>({
@@ -15,10 +15,10 @@ export function registerVisibilityHooks<T extends MotionVariants>({
     const { stop: stopObserver } = useIntersectionObserver(
       target,
       ([{ isIntersecting }]) => {
+        variant.value = 'initial'
+
         if (isIntersecting) {
-          variant.value = 'visible'
-        } else {
-          variant.value = 'initial'
+          nextTick(() => (variant.value = 'visible'))
         }
       },
     )


### PR DESCRIPTION
Hello,

I finally got time to dig a bit and found a way to make visible hooks work even if the element is visible from the start. But I'm not sure this solution doesn't affect other part of the project, so this is mainly a WIP proposition.

The issue was mainly that `useIntersectionObserver` which all visibility hooks rely on doesn't detect intersection on first load when used in the `created` lifecycle (probably because the target element is not mounted in the app yet).

I changed the directive file to register on `mounted` instead, so `useIntersectionObserver` would work even on first load, as I'm not familiar with the rest of the codebase, I'm guessing this is actually wrong and `created` hook is used for a specific reason. I'm open to an alternative solution on this one.

Cheers

Related issue:
#29 