### PR TITLE
Update Docs: Positive y lowers element

### DIFF
--- a/docs/variants.md
+++ b/docs/variants.md
@@ -43,7 +43,7 @@ It is **recommended** to **include** a base state for **each parameter** that yo
 />
 ```
 
-##### _This element will be hidden, and 100px above of its original position._ ☝️
+##### _This element will be hidden, and 100px below its original position._ ☝️
 
 ## Lifecycle Variants
 


### PR DESCRIPTION
Update wording in docs to reflect that a positive 'y' number lowers the element.
So `y: 100` is 100px below 0, `y: -100` is 100px above 0.