### PR TITLE
Add appear ( visible once ) variant

### DIFF
--- a/src/features/visibilityHooks.ts
+++ b/src/features/visibilityHooks.ts
@@ -23,6 +23,20 @@ export function registerVisibilityHooks<T extends MotionVariants>({
     stop = stopObserver
   }
 
+  if (_variants && _variants.appear) {
+    const { stop: stopObserver } = useIntersectionObserver(
+      target,
+      ([{ isIntersecting }]) => {
+        if (isIntersecting) {
+          variant.value = 'appear'
+          stop()
+        }
+      },
+    )
+
+    stop = stopObserver
+  }
+
   return {
     stop,
   }

--- a/src/types/instance.ts
+++ b/src/types/instance.ts
@@ -91,6 +91,7 @@ declare module '@vue/runtime-dom' {
     leave?: Variant
     // Intersection observer variants
     visible?: Variant
+    appear?: Variant
     // Event listeners variants
     hovered?: Variant
     tapped?: Variant

--- a/src/types/variants.ts
+++ b/src/types/variants.ts
@@ -92,6 +92,7 @@ export interface MotionVariants {
   leave?: Variant
   // Intersection observer variants
   visible?: Variant
+  appear?: Variant
   // Event listeners variants
   hovered?: Variant
   tapped?: Variant

--- a/src/utils/directive.ts
+++ b/src/utils/directive.ts
@@ -7,6 +7,7 @@ const directivePropsKeys = [
   'enter',
   'leave',
   'visible',
+  'appear',
   'hovered',
   'tapped',
   'focused',


### PR DESCRIPTION
This PR adds a new variant prop called `appear` which works similar to `visible` except that it only applies the animations once.
It does not reset the animation when the element leaves the viewport and it stops the Intersection Observer once the `variant.value` is applied.

```html
<div
    v-motion
    :initial="{ opacity: 0 }"
    :appear="{ opacity: 1 }"
>
```

This also solves #40 I believe.