### PR TITLE
fix(nuxt): update compatibility field

### DIFF
--- a/src/nuxt/module.ts
+++ b/src/nuxt/module.ts
@@ -10,7 +10,7 @@ export default defineNuxtModule<ModuleOptions>({
     name: '@vueuse/motion',
     configKey: CONFIG_KEY,
     compatibility: {
-      nuxt: '>=3.0.0',
+      nuxt: '^3.0.0-rc.3',
       bridge: true,
     },
   },


### PR DESCRIPTION
Nuxt module stopped working after an upgrade to nuxt rc.9, this should fix the issue.

The warning that popped up after upgrade:

``` 
WARN  Module @vueuse/motion is disabled due to incompatibility issues:                                                                                                                                                                                                                                                                                          14:06:27
 - [nuxt] Nuxt version `>=3.0.0` is required but currently using `3.0.0-rc.9`
```

Some context: https://github.com/nuxt/framework/issues/7196