### PR TITLE
Updating `hovered`, `focused` and `tapped` examples [#63]

### DIFF
--- a/docs/variants.md
+++ b/docs/variants.md
@@ -165,6 +165,9 @@ A regular hover event listener, it will not work on mobile devices.
   :initial="{
     scale: 1,
   }"
+  :visible="{
+    scale: 1,
+  }"
   :hovered="{
     scale: 1.2,
   }"
@@ -181,6 +184,9 @@ A regular focus event listener.
 <div
   v-motion
   :initial="{
+    scale: 1,
+  }"
+  :visible="{
     scale: 1,
   }"
   :focused="{
@@ -201,6 +207,9 @@ It will switch between them depending on the user supported pointer events.
 <div
   v-motion
   :initial="{
+    scale: 1,
+  }"
+  :hovered="{
     scale: 1,
   }"
   :tapped="{


### PR DESCRIPTION
https://stackblitz.com/edit/vue-eeacxc?file=src%2FApp.vue
https://github.com/vueuse/motion/issues/63#issuecomment-1409009281

Elements with `:hovered` variant do not return to `:initial` on mouseleave, on Firefox it works well returning to `:visible`, on Chrome both `:visible` and `:initial` seems to be required.

---

When using `:tapped` without `:hovered`, elements do not return to `:initial` if you click and move the mouse out of the element keeping it clicked.