### PR TITLE
docs: fix MotionDirective import in component level installation example

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,11 +33,11 @@ app.mount('#app')
 If you want to import the directive code only from components that uses it, import the directive and install it at component level.
 
 ```javascript
-import { directive as motion } from '@vueuse/motion'
+import { MotionDirective } from '@vueuse/motion'
 
 export default {
   directives: {
-    motion: motion(),
+    motion: MotionDirective(),
   },
 }
 ```


### PR DESCRIPTION
@vueuse/motion exports has no exported member `directive ` it exports `directive as MotionDirective` instead. 

I stumbled on this while trying to use the motion on component level and using the example from the current docs. 
(using 2.0.0-beta.12)