### PR TITLE
Resolve issue

### DIFF
--- a/src/utils/transform-parser.ts
+++ b/src/utils/transform-parser.ts
@@ -78,7 +78,7 @@ export function stateFromTransform(
       }
 
       // Loop on parsed scale / translate definition
-      value.forEach((axisValue: ResolvedValueTarget, index: number) => {
+      Object.values(parseTransform(transform))[0].forEach((axisValue: ResolvedValueTarget, index: number) => {
         __set(state, axes[index], axisValue)
       })
 


### PR DESCRIPTION
If only `x` is set, transform is `translate3d(100px, 0, 0)`, and value is `100`. Trying `value.forEach` causing error