### PR TITLE
Add dynamic keys on useMotion directives when calling apply() and other methods

### DIFF
--- a/playgrounds/vite/src/demos/Editor.vue
+++ b/playgrounds/vite/src/demos/Editor.vue
@@ -1,5 +1,5 @@
 <script setup="props" lang="ts">
-import { useMotions } from '@vueuse/motion'
+import { useMotions, useMotion } from '@vueuse/motion'
 import { computed, ref, watch } from 'vue'
 import DemoBox from '../components/DemoBox.vue'
 import basic from '../examples/basic'
@@ -7,6 +7,18 @@ import basic from '../examples/basic'
 const motions = useMotions()
 
 const input = ref<string>('0')
+const el = ref<HTMLDivElement>()
+
+const { apply } = useMotion(el, {
+  start: {
+    scale: 0
+  },
+  end: {
+    scale: 1
+  }
+})
+
+apply('end')
 
 const codeText = computed(() => basic(input.value))
 

--- a/playgrounds/vite/src/demos/Editor.vue
+++ b/playgrounds/vite/src/demos/Editor.vue
@@ -1,5 +1,5 @@
 <script setup="props" lang="ts">
-import { useMotions, useMotion } from '@vueuse/motion'
+import { useMotions } from '@vueuse/motion'
 import { computed, ref, watch } from 'vue'
 import DemoBox from '../components/DemoBox.vue'
 import basic from '../examples/basic'
@@ -7,18 +7,6 @@ import basic from '../examples/basic'
 const motions = useMotions()
 
 const input = ref<string>('0')
-const el = ref<HTMLDivElement>()
-
-const { apply } = useMotion(el, {
-  start: {
-    scale: 0
-  },
-  end: {
-    scale: 1
-  }
-})
-
-apply('end')
 
 const codeText = computed(() => basic(input.value))
 

--- a/src/components/Motion.ts
+++ b/src/components/Motion.ts
@@ -20,12 +20,12 @@ export default defineComponent({
     },
     // Instance
     instance: {
-      type: Object as PropType<MotionInstance>,
+      type: Object as PropType<MotionInstance<string, MotionVariants<string>>>,
       required: false,
     },
     // Variants
     variants: {
-      type: Object as PropType<MotionVariants>,
+      type: Object as PropType<MotionVariants<string>>,
       required: false,
     },
     // Initial variant
@@ -74,7 +74,7 @@ export default defineComponent({
     const slots = useSlots()
 
     // Instance map from component content
-    const instances = reactive<{ [key: number]: MotionInstance<any> }>({})
+    const instances = reactive<{ [key: number]: MotionInstance<string, MotionVariants<string>> }>({})
 
     // Return empty component is `is` is absent
     if (!props.is && !slots.default) return () => h('div', {})
@@ -128,7 +128,7 @@ export default defineComponent({
 
     // Replay animations on component update Vue
     if (process?.env?.NODE_ENV === 'development' || (process as any)?.dev) {
-      const replayAnimation = (instance: MotionInstance<any>) => {
+      const replayAnimation = (instance: MotionInstance<any, any>) => {
         if (instance.variants?.initial) instance.set('initial')
         setTimeout(() => {
           if (instance.variants?.enter) instance.apply('enter')

--- a/src/directive/index.ts
+++ b/src/directive/index.ts
@@ -1,4 +1,4 @@
-import type { Directive, DirectiveBinding, VNode } from 'vue'
+import type { Directive, DirectiveBinding, Ref, VNode } from 'vue'
 import defu from 'defu'
 import { ref, unref } from 'vue'
 import { motionState } from '../features/state'
@@ -7,7 +7,7 @@ import { useMotion } from '../useMotion'
 import { resolveVariants } from '../utils/directive'
 import { variantToStyle } from '../utils/transform'
 
-export function directive(variants?: MotionVariants): Directive<HTMLElement | SVGElement> {
+export function directive<T extends string>(variants: MotionVariants<T> = {}): Directive<HTMLElement | SVGElement> {
   const register = (el: HTMLElement | SVGElement, binding: DirectiveBinding, node: VNode<any, HTMLElement | SVGElement, Record<string, any>>) => {
     // Get instance key if possible (binding value or element key in case of v-for's)
     const key = (binding.value && typeof binding.value === 'string' ? binding.value : node.key) as string
@@ -16,13 +16,13 @@ export function directive(variants?: MotionVariants): Directive<HTMLElement | SV
     if (key && motionState[key]) motionState[key].stop()
 
     // Initialize variants with argument
-    const variantsRef = ref<MotionVariants>(variants || {})
+    const variantsRef = ref(variants) as Ref<MotionVariants<T>>
 
     // Set variants from v-motion binding
     if (typeof binding.value === 'object') variantsRef.value = binding.value
 
     // Resolve variants from node props
-    resolveVariants(node, variantsRef)
+    resolveVariants<T>(node, variantsRef)
 
     // Create motion instance
     const motionInstance = useMotion(el, variantsRef)

--- a/src/features/eventListeners.ts
+++ b/src/features/eventListeners.ts
@@ -3,7 +3,7 @@ import { computed, ref, unref, watch } from 'vue'
 import type { MotionInstance, MotionVariants } from '../types'
 import { supportsMouseEvents, supportsPointerEvents, supportsTouchEvents } from '../utils/events'
 
-export function registerEventListeners<T extends MotionVariants>({ target, state, variants, apply }: MotionInstance<T>) {
+export function registerEventListeners<T extends string, V extends MotionVariants<T>>({ target, state, variants, apply }: MotionInstance<T, V>) {
   const _variants = unref(variants)
 
   // State
@@ -37,6 +37,7 @@ export function registerEventListeners<T extends MotionVariants>({ target, state
     if (focused.value && _variants.focused) Object.assign(result, _variants.focused)
 
     for (const key in result) {
+      // @ts-expect-error - Fix errors later for typescript 5
       if (!mutableKeys.value.includes(key)) delete result[key]
     }
 

--- a/src/features/lifeCycleHooks.ts
+++ b/src/features/lifeCycleHooks.ts
@@ -1,7 +1,7 @@
 import { unref, watch } from 'vue'
 import type { MotionInstance, MotionVariants } from '../types'
 
-export function registerLifeCycleHooks<T extends MotionVariants>({ set, target, variants, variant }: MotionInstance<T>) {
+export function registerLifeCycleHooks<T extends string, V extends MotionVariants<T>>({ set, target, variants, variant }: MotionInstance<T, V>) {
   const _variants = unref(variants)
 
   watch(

--- a/src/features/state.ts
+++ b/src/features/state.ts
@@ -1,3 +1,3 @@
-import type { MotionInstanceBindings } from '../types'
+import type { MotionInstanceBindings, MotionVariants } from '../types'
 
-export const motionState: MotionInstanceBindings<any> = {}
+export const motionState: MotionInstanceBindings<string, MotionVariants<never>> = {}

--- a/src/features/syncVariants.ts
+++ b/src/features/syncVariants.ts
@@ -1,7 +1,7 @@
 import { watch } from 'vue'
 import type { MotionInstance, MotionVariants } from '../types'
 
-export function registerVariantsSync<T extends MotionVariants>({ state, apply }: MotionInstance<T>) {
+export function registerVariantsSync<T extends string, V extends MotionVariants<T>>({ state, apply }: MotionInstance<T, V>) {
   // Watch for variant changes and apply the new one
   watch(
     state,

--- a/src/features/visibilityHooks.ts
+++ b/src/features/visibilityHooks.ts
@@ -2,7 +2,7 @@ import { useIntersectionObserver } from '@vueuse/core'
 import { unref } from 'vue'
 import type { MotionInstance, MotionVariants } from '../types'
 
-export function registerVisibilityHooks<T extends MotionVariants>({ target, variants, variant }: MotionInstance<T>) {
+export function registerVisibilityHooks<T extends string, V extends MotionVariants<T>>({ target, variants, variant }: MotionInstance<T, V>) {
   const _variants = unref(variants)
 
   // Bind intersection observer on target

--- a/src/nuxt/module.ts
+++ b/src/nuxt/module.ts
@@ -2,7 +2,7 @@ import { defu } from 'defu'
 import { addImportsDir, addPlugin, createResolver, defineNuxtModule } from '@nuxt/kit'
 import type { ModuleOptions as MotionModuleOpts } from '../types'
 
-export interface ModuleOptions extends MotionModuleOpts {}
+export interface ModuleOptions extends MotionModuleOpts<string> { }
 
 export default defineNuxtModule<ModuleOptions>({
   meta: {

--- a/src/nuxt/module.ts
+++ b/src/nuxt/module.ts
@@ -2,7 +2,7 @@ import { defu } from 'defu'
 import { addImportsDir, addPlugin, createResolver, defineNuxtModule } from '@nuxt/kit'
 import type { ModuleOptions as MotionModuleOpts } from '../types'
 
-export interface ModuleOptions extends MotionModuleOpts<string> { }
+export interface ModuleOptions extends MotionModuleOpts<string> {}
 
 export default defineNuxtModule<ModuleOptions>({
   meta: {

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -6,7 +6,7 @@ import type { MotionPluginOptions, MotionVariants } from '../types'
 import { slugify } from '../utils/slugify'
 
 export const MotionPlugin: Plugin = {
-  install(app, options: MotionPluginOptions) {
+  install(app, options: MotionPluginOptions<string>) {
     // Register default `v-motion` directive
     app.directive('motion', directive())
 
@@ -30,7 +30,7 @@ export const MotionPlugin: Plugin = {
       // Loop on options, create a custom directive for each definition
       for (const key in options.directives) {
         // Get directive variants
-        const variants = options.directives[key] as MotionVariants
+        const variants = options.directives[key] as MotionVariants<any>
 
         // Development warning, showing definitions missing `initial` key
         if (!variants.initial && __DEV__) {

--- a/src/presets/fade.ts
+++ b/src/presets/fade.ts
@@ -1,6 +1,6 @@
 import type { MotionVariants } from '../types'
 
-export const fade: MotionVariants = {
+export const fade: MotionVariants<never> = {
   initial: {
     opacity: 0,
   },
@@ -9,7 +9,7 @@ export const fade: MotionVariants = {
   },
 }
 
-export const fadeVisible: MotionVariants = {
+export const fadeVisible: MotionVariants<never> = {
   initial: {
     opacity: 0,
   },
@@ -18,7 +18,7 @@ export const fadeVisible: MotionVariants = {
   },
 }
 
-export const fadeVisibleOnce: MotionVariants = {
+export const fadeVisibleOnce: MotionVariants<never> = {
   initial: {
     opacity: 0,
   },

--- a/src/presets/pop.ts
+++ b/src/presets/pop.ts
@@ -1,6 +1,6 @@
 import type { MotionVariants } from '../types'
 
-export const pop: MotionVariants = {
+export const pop: MotionVariants<never> = {
   initial: {
     scale: 0,
     opacity: 0,
@@ -11,7 +11,7 @@ export const pop: MotionVariants = {
   },
 }
 
-export const popVisible: MotionVariants = {
+export const popVisible: MotionVariants<never> = {
   initial: {
     scale: 0,
     opacity: 0,
@@ -22,7 +22,7 @@ export const popVisible: MotionVariants = {
   },
 }
 
-export const popVisibleOnce: MotionVariants = {
+export const popVisibleOnce: MotionVariants<never> = {
   initial: {
     scale: 0,
     opacity: 0,

--- a/src/presets/roll.ts
+++ b/src/presets/roll.ts
@@ -2,7 +2,7 @@ import type { MotionVariants } from '../types'
 
 // Roll from left
 
-export const rollLeft: MotionVariants = {
+export const rollLeft: MotionVariants<never> = {
   initial: {
     x: -100,
     rotate: 90,
@@ -15,7 +15,7 @@ export const rollLeft: MotionVariants = {
   },
 }
 
-export const rollVisibleLeft: MotionVariants = {
+export const rollVisibleLeft: MotionVariants<never> = {
   initial: {
     x: -100,
     rotate: 90,
@@ -28,7 +28,7 @@ export const rollVisibleLeft: MotionVariants = {
   },
 }
 
-export const rollVisibleOnceLeft: MotionVariants = {
+export const rollVisibleOnceLeft: MotionVariants<never> = {
   initial: {
     x: -100,
     rotate: 90,
@@ -43,7 +43,7 @@ export const rollVisibleOnceLeft: MotionVariants = {
 
 // Roll from right
 
-export const rollRight: MotionVariants = {
+export const rollRight: MotionVariants<never> = {
   initial: {
     x: 100,
     rotate: -90,
@@ -56,7 +56,7 @@ export const rollRight: MotionVariants = {
   },
 }
 
-export const rollVisibleRight: MotionVariants = {
+export const rollVisibleRight: MotionVariants<never> = {
   initial: {
     x: 100,
     rotate: -90,
@@ -69,7 +69,7 @@ export const rollVisibleRight: MotionVariants = {
   },
 }
 
-export const rollVisibleOnceRight: MotionVariants = {
+export const rollVisibleOnceRight: MotionVariants<never> = {
   initial: {
     x: 100,
     rotate: -90,
@@ -84,7 +84,7 @@ export const rollVisibleOnceRight: MotionVariants = {
 
 // Roll from top
 
-export const rollTop: MotionVariants = {
+export const rollTop: MotionVariants<never> = {
   initial: {
     y: -100,
     rotate: -90,
@@ -97,7 +97,7 @@ export const rollTop: MotionVariants = {
   },
 }
 
-export const rollVisibleTop: MotionVariants = {
+export const rollVisibleTop: MotionVariants<never> = {
   initial: {
     y: -100,
     rotate: -90,
@@ -110,7 +110,7 @@ export const rollVisibleTop: MotionVariants = {
   },
 }
 
-export const rollVisibleOnceTop: MotionVariants = {
+export const rollVisibleOnceTop: MotionVariants<never> = {
   initial: {
     y: -100,
     rotate: -90,
@@ -125,7 +125,7 @@ export const rollVisibleOnceTop: MotionVariants = {
 
 // Roll from bottom
 
-export const rollBottom: MotionVariants = {
+export const rollBottom: MotionVariants<never> = {
   initial: {
     y: 100,
     rotate: 90,
@@ -138,7 +138,7 @@ export const rollBottom: MotionVariants = {
   },
 }
 
-export const rollVisibleBottom: MotionVariants = {
+export const rollVisibleBottom: MotionVariants<never> = {
   initial: {
     y: 100,
     rotate: 90,
@@ -151,7 +151,7 @@ export const rollVisibleBottom: MotionVariants = {
   },
 }
 
-export const rollVisibleOnceBottom: MotionVariants = {
+export const rollVisibleOnceBottom: MotionVariants<never> = {
   initial: {
     y: 100,
     rotate: 90,

--- a/src/presets/slide.ts
+++ b/src/presets/slide.ts
@@ -2,7 +2,7 @@ import type { MotionVariants } from '../types'
 
 // Slide from left
 
-export const slideLeft: MotionVariants = {
+export const slideLeft: MotionVariants<never> = {
   initial: {
     x: -100,
     opacity: 0,
@@ -13,7 +13,7 @@ export const slideLeft: MotionVariants = {
   },
 }
 
-export const slideVisibleLeft: MotionVariants = {
+export const slideVisibleLeft: MotionVariants<never> = {
   initial: {
     x: -100,
     opacity: 0,
@@ -24,7 +24,7 @@ export const slideVisibleLeft: MotionVariants = {
   },
 }
 
-export const slideVisibleOnceLeft: MotionVariants = {
+export const slideVisibleOnceLeft: MotionVariants<never> = {
   initial: {
     x: -100,
     opacity: 0,
@@ -37,7 +37,7 @@ export const slideVisibleOnceLeft: MotionVariants = {
 
 // Slide from right
 
-export const slideRight: MotionVariants = {
+export const slideRight: MotionVariants<never> = {
   initial: {
     x: 100,
     opacity: 0,
@@ -48,7 +48,7 @@ export const slideRight: MotionVariants = {
   },
 }
 
-export const slideVisibleRight: MotionVariants = {
+export const slideVisibleRight: MotionVariants<never> = {
   initial: {
     x: 100,
     opacity: 0,
@@ -59,7 +59,7 @@ export const slideVisibleRight: MotionVariants = {
   },
 }
 
-export const slideVisibleOnceRight: MotionVariants = {
+export const slideVisibleOnceRight: MotionVariants<never> = {
   initial: {
     x: 100,
     opacity: 0,
@@ -72,7 +72,7 @@ export const slideVisibleOnceRight: MotionVariants = {
 
 // Slide from top
 
-export const slideTop: MotionVariants = {
+export const slideTop: MotionVariants<never> = {
   initial: {
     y: -100,
     opacity: 0,
@@ -83,7 +83,7 @@ export const slideTop: MotionVariants = {
   },
 }
 
-export const slideVisibleTop: MotionVariants = {
+export const slideVisibleTop: MotionVariants<never> = {
   initial: {
     y: -100,
     opacity: 0,
@@ -94,7 +94,7 @@ export const slideVisibleTop: MotionVariants = {
   },
 }
 
-export const slideVisibleOnceTop: MotionVariants = {
+export const slideVisibleOnceTop: MotionVariants<never> = {
   initial: {
     y: -100,
     opacity: 0,
@@ -107,7 +107,7 @@ export const slideVisibleOnceTop: MotionVariants = {
 
 // Slide from bottom
 
-export const slideBottom: MotionVariants = {
+export const slideBottom: MotionVariants<never> = {
   initial: {
     y: 100,
     opacity: 0,
@@ -118,7 +118,7 @@ export const slideBottom: MotionVariants = {
   },
 }
 
-export const slideVisibleBottom: MotionVariants = {
+export const slideVisibleBottom: MotionVariants<never> = {
   initial: {
     y: 100,
     opacity: 0,
@@ -129,7 +129,7 @@ export const slideVisibleBottom: MotionVariants = {
   },
 }
 
-export const slideVisibleOnceBottom: MotionVariants = {
+export const slideVisibleOnceBottom: MotionVariants<never> = {
   initial: {
     y: 100,
     opacity: 0,

--- a/src/types/instance.ts
+++ b/src/types/instance.ts
@@ -6,10 +6,10 @@ export type PermissiveTarget = VueInstance | MotionTarget
 
 export type MotionTarget = HTMLElement | SVGElement | null | undefined
 
-export interface MotionInstance<T = MotionVariants> extends MotionControls {
+export interface MotionInstance<T extends string, V extends MotionVariants<T>> extends MotionControls<T, V> {
   target: MaybeRef<PermissiveTarget>
-  variants: MaybeRef<T>
-  variant: Ref<keyof T>
+  variants: MaybeRef<V>
+  variant: Ref<keyof V>
   state: Ref<Variant | undefined>
   motionProperties: UnwrapRef<MotionProperties>
 }
@@ -21,20 +21,20 @@ export interface UseMotionOptions {
   eventListeners?: boolean
 }
 
-export interface MotionControls {
+export interface MotionControls<T extends string, V extends MotionVariants<T>> {
   /**
    * Apply a variant declaration and execute the resolved transitions.
    *
    * @param variant
    * @returns Promise<void[]>
    */
-  apply: (variant: Variant | string) => Promise<void[]> | undefined
+  apply: (variant: Variant | keyof V) => Promise<void[]> | undefined
   /**
    * Apply a variant declaration without transitions.
    *
    * @param variant
    */
-  set: (variant: Variant | string) => void
+  set: (variant: Variant | keyof V) => void
   /**
    * Stop all the ongoing transitions for the current element.
    */
@@ -72,17 +72,17 @@ export interface SpringControls {
   values: MotionProperties
 }
 
-export type MotionInstanceBindings<T> = Record<string, MotionInstance<T>>
+export type MotionInstanceBindings<T extends string, V extends MotionVariants<T>> = Record<string, MotionInstance<T, V>>
 
 declare module '@vue/runtime-core' {
   export interface ComponentCustomProperties {
-    $motions?: MotionInstanceBindings<any>
+    $motions?: MotionInstanceBindings<any, any>
   }
 }
 
 declare module '@vue/runtime-dom' {
   interface HTMLAttributes {
-    variants?: MotionVariants
+    variants?: MotionVariants<any>
     // Initial variant
     initial?: Variant
     // Lifecycle hooks variants

--- a/src/types/nuxt.ts
+++ b/src/types/nuxt.ts
@@ -1,6 +1,6 @@
 import type { MotionVariants } from './variants'
 
-export interface ModuleOptions {
-  directives?: Record<string, MotionVariants>
+export interface ModuleOptions<T extends string> {
+  directives?: Record<T, MotionVariants<T>>
   excludePresets?: boolean
 }

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -1,6 +1,6 @@
 import type { MotionVariants } from './variants'
 
-export interface MotionPluginOptions {
-  directives?: Record<string, MotionVariants>
+export interface MotionPluginOptions<T extends string> {
+  directives?: Record<T, MotionVariants<T>>
   excludePresets?: boolean
 }

--- a/src/types/variants.ts
+++ b/src/types/variants.ts
@@ -83,6 +83,6 @@ export type MotionVariants<T extends string> = {
   tapped?: Variant
   focused?: Variant
 } & {
-    // Custom variants
-    [key in T]?: Variant
-  }
+  // Custom variants
+  [key in T]?: Variant
+}

--- a/src/types/variants.ts
+++ b/src/types/variants.ts
@@ -69,7 +69,7 @@ export type Variant = {
 /**
  * Motion variants object
  */
-export interface MotionVariants {
+export type MotionVariants<T extends string> = {
   // Initial variant
   initial?: Variant
   // Lifecycle hooks variants
@@ -82,6 +82,7 @@ export interface MotionVariants {
   hovered?: Variant
   tapped?: Variant
   focused?: Variant
-  // Custom variants
-  [key: string]: Variant | undefined
-}
+} & {
+    // Custom variants
+    [key in T]?: Variant
+  }

--- a/src/useMotion.ts
+++ b/src/useMotion.ts
@@ -14,18 +14,18 @@ import { useMotionVariants } from './useMotionVariants'
  * @param variants
  * @param options
  */
-export function useMotion<T extends MotionVariants>(target: MaybeRef<PermissiveTarget>, variants: MaybeRef<T> = {} as MaybeRef<T>, options?: UseMotionOptions) {
+export function useMotion<T extends string, V extends MotionVariants<T>>(target: MaybeRef<PermissiveTarget>, variants: MaybeRef<V> = {} as MaybeRef<V>, options?: UseMotionOptions) {
   // Reactive styling and transform
   const { motionProperties } = useMotionProperties(target)
 
   // Variants manager
-  const { variant, state } = useMotionVariants<T>(variants)
+  const { variant, state } = useMotionVariants<T, V>(variants)
 
   // Motion controls, synchronized with motion properties and variants
-  const controls = useMotionControls<T>(motionProperties, variants)
+  const controls = useMotionControls<T, V>(motionProperties, variants)
 
   // Create motion instance
-  const instance: MotionInstance<T> = {
+  const instance: MotionInstance<T, V> = {
     target,
     variant,
     variants,

--- a/src/useMotion.ts
+++ b/src/useMotion.ts
@@ -14,7 +14,11 @@ import { useMotionVariants } from './useMotionVariants'
  * @param variants
  * @param options
  */
-export function useMotion<T extends string, V extends MotionVariants<T>>(target: MaybeRef<PermissiveTarget>, variants: MaybeRef<V> = {} as MaybeRef<V>, options?: UseMotionOptions) {
+export function useMotion<T extends string, V extends MotionVariants<T>>(
+  target: MaybeRef<PermissiveTarget>,
+  variants: MaybeRef<V> = {} as MaybeRef<V>,
+  options?: UseMotionOptions
+) {
   // Reactive styling and transform
   const { motionProperties } = useMotionProperties(target)
 

--- a/src/useMotion.ts
+++ b/src/useMotion.ts
@@ -17,7 +17,7 @@ import { useMotionVariants } from './useMotionVariants'
 export function useMotion<T extends string, V extends MotionVariants<T>>(
   target: MaybeRef<PermissiveTarget>,
   variants: MaybeRef<V> = {} as MaybeRef<V>,
-  options?: UseMotionOptions
+  options?: UseMotionOptions,
 ) {
   // Reactive styling and transform
   const { motionProperties } = useMotionProperties(target)

--- a/src/useMotionControls.ts
+++ b/src/useMotionControls.ts
@@ -12,13 +12,13 @@ import { getDefaultTransition } from './utils/defaults'
  * @param style
  * @param currentVariant
  */
-export function useMotionControls<T extends MotionVariants>(
+export function useMotionControls<T extends string, V extends MotionVariants<T>>(
   motionProperties: MotionProperties,
-  variants: MaybeRef<T> = {} as MaybeRef<T>,
+  variants: MaybeRef<V> = {} as MaybeRef<V>,
   { motionValues, push, stop }: MotionTransitions = useMotionTransitions(),
-): MotionControls {
+): MotionControls<T, V> {
   // Variants as ref
-  const _variants = unref(variants) as T
+  const _variants = unref(variants)
 
   // Is the current instance animated ref
   const isAnimating = ref(false)
@@ -36,13 +36,13 @@ export function useMotionControls<T extends MotionVariants>(
     },
   )
 
-  const getVariantFromKey = (variant: keyof T): Variant => {
+  const getVariantFromKey = (variant: keyof V): Variant => {
     if (!_variants || !_variants[variant]) throw new Error(`The variant ${variant as string} does not exist.`)
 
     return _variants[variant] as Variant
   }
 
-  const apply = (variant: Variant | keyof T): Promise<void[]> | undefined => {
+  const apply = (variant: Variant | keyof V): Promise<void[]> | undefined => {
     // If variant is a key, try to resolve it
     if (typeof variant === 'string') variant = getVariantFromKey(variant)
 
@@ -62,7 +62,7 @@ export function useMotionControls<T extends MotionVariants>(
     )
   }
 
-  const set = (variant: Variant | keyof T) => {
+  const set = (variant: Variant | keyof V) => {
     // Get variant data from parameter
     const variantData = isObject(variant) ? variant : getVariantFromKey(variant)
 

--- a/src/useMotionFeatures.ts
+++ b/src/useMotionFeatures.ts
@@ -14,8 +14,8 @@ import type { MotionInstance, MotionVariants, UseMotionOptions } from './types'
  * @param variants
  * @param options
  */
-export function useMotionFeatures<T extends MotionVariants>(
-  instance: MotionInstance<T>,
+export function useMotionFeatures<T extends string, V extends MotionVariants<T>>(
+  instance: MotionInstance<T, V>,
   options: UseMotionOptions = {
     syncVariants: true,
     lifeCycleHooks: true,

--- a/src/useMotionValues.ts
+++ b/src/useMotionValues.ts
@@ -43,6 +43,7 @@ export function useMotionValues() {
     const motionValue = getMotionValue(from)
 
     // Set motion properties mapping
+    // @ts-expect-error - Fix errors later for typescript 5
     motionValue.onChange((v) => (target[key] = v))
 
     // Set instance motion value

--- a/src/useMotionVariants.ts
+++ b/src/useMotionVariants.ts
@@ -10,12 +10,12 @@ import type { MotionVariants, Variant } from './types'
  * @param initial
  * @param options
  */
-export function useMotionVariants<T extends MotionVariants>(variants: MaybeRef<T> = {} as MaybeRef<T>) {
+export function useMotionVariants<T extends string, V extends MotionVariants<T>>(variants: MaybeRef<V> = {} as MaybeRef<V>) {
   // Unref variants
-  const _variants = unref(variants) as T
+  const _variants = unref(variants)
 
   // Current variant string
-  const variant = ref() as Ref<keyof T>
+  const variant = ref() as Ref<keyof V>
 
   // Current variant state
   const state = computed<Variant | undefined>(() => {

--- a/src/utils/defaults.ts
+++ b/src/utils/defaults.ts
@@ -75,6 +75,7 @@ export function getDefaultTransition(valueKey: string, to: ValueTarget): Popmoti
   if (isKeyframesTarget(to)) {
     transitionFactory = keyframes as TransitionFactory
   } else {
+    // @ts-expect-error - Fix errors later for typescript 5
     transitionFactory = defaultTransitions[valueKey] || defaultTransitions.default
   }
 

--- a/src/utils/directive.ts
+++ b/src/utils/directive.ts
@@ -4,15 +4,15 @@ import type { MotionVariants } from '../types'
 
 const directivePropsKeys = ['initial', 'enter', 'leave', 'visible', 'visible-once', 'hovered', 'tapped', 'focused', 'delay']
 
-export function resolveVariants(node: VNode<any, HTMLElement | SVGElement, Record<string, any>>, variantsRef: Ref<MotionVariants>) {
+export function resolveVariants<T extends string>(node: VNode<any, HTMLElement | SVGElement, Record<string, any>>, variantsRef: Ref<MotionVariants<T>>) {
   // This is done to achieve compat with Vue 2 & 3
   // node.props = Vue 3 element props location
   // node.data.attrs = Vue 2 element props location
   const target = node.props
     ? node.props // @ts-expect-error - Compatibility (Vue 3)
     : node.data && node.data.attrs // @ts-expect-error - Compatibility (Vue 2)
-    ? node.data.attrs
-    : {}
+      ? node.data.attrs
+      : {}
 
   if (target) {
     if (target.variants && isObject(target.variants)) {
@@ -64,6 +64,7 @@ export function resolveVariants(node: VNode<any, HTMLElement | SVGElement, Recor
 
       if (key === 'visible-once') key = 'visibleOnce'
 
+      // @ts-expect-error - Fix errors later for typescript 5
       if (target && target[key] && isObject(target[key])) variantsRef.value[key] = target[key]
     })
   }

--- a/src/utils/directive.ts
+++ b/src/utils/directive.ts
@@ -11,8 +11,8 @@ export function resolveVariants<T extends string>(node: VNode<any, HTMLElement |
   const target = node.props
     ? node.props // @ts-expect-error - Compatibility (Vue 3)
     : node.data && node.data.attrs // @ts-expect-error - Compatibility (Vue 2)
-      ? node.data.attrs
-      : {}
+    ? node.data.attrs
+    : {}
 
   if (target) {
     if (target.variants && isObject(target.variants)) {

--- a/src/utils/is-motion-instance.ts
+++ b/src/utils/is-motion-instance.ts
@@ -1,5 +1,5 @@
 import { isRef } from 'vue'
-import type { MotionInstance } from '../types'
+import type { MotionInstance, MotionVariants } from '../types'
 
 /**
  * Check whether an object is a Motion Instance or not.
@@ -9,8 +9,8 @@ import type { MotionInstance } from '../types'
  * @param obj
  * @returns bool
  */
-export function isMotionInstance(obj: any): obj is MotionInstance {
-  const _obj = obj as MotionInstance
+export function isMotionInstance<T extends string, V extends MotionVariants<T>>(obj: any): obj is MotionInstance<T, V> {
+  const _obj = obj as MotionInstance<T, V>
 
   return _obj.apply !== undefined && typeof _obj.apply === 'function' && _obj.set !== undefined && typeof _obj.set === 'function' && _obj.target !== undefined && isRef(_obj.target)
 }

--- a/src/utils/transform-parser.ts
+++ b/src/utils/transform-parser.ts
@@ -60,11 +60,13 @@ export function stateFromTransform(state: TransformProperties, transform: string
     // Handle translate3d and scale3d
     if (key === 'translate3d') {
       if (value === 0) {
+        // @ts-expect-error - Fix errors later for typescript 5
         axes.forEach((axis) => (state[axis] = 0))
         return
       }
 
       // Loop on parsed scale / translate definition
+      // @ts-expect-error - Fix errors later for typescript 5
       value.forEach((axisValue: ResolvedValueTarget, index: number) => (state[axes[index]] = axisValue))
 
       return
@@ -92,6 +94,7 @@ export function stateFromTransform(state: TransformProperties, transform: string
     }
 
     // Set raw value
+    // @ts-expect-error - Fix errors later for typescript 5
     state[key] = value
   })
 }


### PR DESCRIPTION
@Tahul 
Adding support for strict typing of the directive keys when creating a motion instance using useMotion and other methods.
![image](https://github.com/vueuse/motion/assets/82461605/36ae74c0-8c7b-4741-9a4a-73a448019616)

I've also added a few other `// @ts-expect-error` that seemed to be missing and caused `tsc` to throw errors. I believe it is cleaner to do it this way rather than do `keyof typeof obj` in every place, since it's something that TypeScript don't intend to change (https://github.com/microsoft/TypeScript/pull/12253#issuecomment-263132208).