### PR TITLE
Add declaration file for motion plugin

### DIFF
--- a/src/nuxt/runtime/templates/motion.d.ts
+++ b/src/nuxt/runtime/templates/motion.d.ts
@@ -1,0 +1,3 @@
+import { Plugin } from "nuxt/app"
+declare const plugin: Plugin<Record<string, unknown>>
+export default plugin


### PR DESCRIPTION
Once building, there's no type shim generated for the motion plugin file. Here's why we need it:

Nuxt auto-generates types while previewing. In the `.nuxt/types/plugins.d.ts` file, the following type is generated that populated the `NuxtApp` interface:

```typescript
type NuxtAppInjections = 
  InjectionType<typeof import("../../../node_modules/@pinia/nuxt/dist/runtime/plugin.vue3").default> &
  InjectionType<typeof import("../../../node_modules/nuxt/dist/app/plugins/revive-payload.server").default> &
  InjectionType<typeof import("../../../node_modules/nuxt/dist/app/plugins/revive-payload.client").default> &
  InjectionType<typeof import("../../../node_modules/nuxt/dist/head/runtime/plugins/unhead").default> &
  InjectionType<typeof import("../../../node_modules/nuxt/dist/pages/runtime/plugins/router").default> &
  InjectionType<typeof import("../../../node_modules/nuxt/dist/pages/runtime/plugins/prefetch.client").default> &
  InjectionType<typeof import("../../../node_modules/@vueuse/motion/dist/runtime/templates/motion").default> &
  {other imports}
```

Because it can't find a type declaration for the motion plugin, it's resolved as `any`, causing the entire `NuxtAppInjections` type to be `any` (as any intersection with `any` will resolve as `any`).

The effect of that is that, if you provide a plugin as, say, `session`, you won't find `$session` in the keys returned by `useNuxtApp()`

This PR adds the relevant shim file to ensure it's gracefully regarded as `unknown`, hence maintaining the types for the plugin helper.