### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/src/nuxt/runtime/templates/motion.ts
+++ b/src/nuxt/runtime/templates/motion.ts
@@ -1,5 +1,5 @@
 import { MotionPlugin } from '@vueuse/motion'
-import { defineNuxtPlugin, useRuntimeConfig } from '#app'
+import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
 
 export default defineNuxtPlugin(
   (nuxtApp) => {


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.