### PR TITLE
fix: add types export

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.mjs"
     },


### PR DESCRIPTION
this issue is included in the latest version of Vue & Nuxt.
<img width="1441" alt="iShot_2024-02-01_13 54 41" src="https://github.com/vueuse/motion/assets/38931843/3ff0f870-9865-43eb-8068-a05b5ddb23aa">

solved this problem.