### PR TITLE
chore: add bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,40 @@
+name: "\U0001F41E Bug report"
+description: Report an issue with @vueuse/motion
+labels: ['pending triage']
+body:
+  - type: textarea
+    id: bug-env
+    attributes:
+      label: System info
+      description: Output of `npx envinfo --system --npmPackages '{vue,@vueuse/*}' --binaries --browsers` or `npx nuxi info` when using nuxt.
+      placeholder: System, Binaries, Browsers
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Please provide a link to a repo or [stackblitz](https://stackblitz.com/edit/vitejs-vite-rptfks/) that can reproduce the problem you ran into. A [**minimal reproduction**](https://stackoverflow.com/help/minimal-reproducible-example) is required.
+      placeholder: Reproduction
+    validations:
+      required: true
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is. If you intend to submit a PR for this issue, tell us in the description. Thanks!
+      placeholder: Bug description
+    validations:
+      required: true
+  - type: textarea
+    id: additonal
+    attributes:
+      label: Additional context
+      description: If applicable, add any other context about the problem here
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        Optional if provided reproduction. Please try not to insert an image but copy paste the log text.
+      render: shell-script

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -6,7 +6,7 @@ body:
     id: bug-env
     attributes:
       label: System info
-      description: Output of `npx envinfo --system --npmPackages '{vue,@vueuse/*}' --binaries --browsers` or `npx nuxi info` when using nuxt.
+      description: Output of `npx envinfo --system --npmPackages '{vue,vite,@vueuse/*}' --binaries --browsers` or `npx nuxi info` when using nuxt.
       placeholder: System, Binaries, Browsers
     validations:
       required: true


### PR DESCRIPTION
Adds a template for users reporting bugs, the template is a bit of a mix between the template of Nuxt and Vueuse. This should also add the `pending triage` label to new reported bugs (this label doesn't exist in this repo so this has to be added).

Hopefully this will increase the likelihood of users adding a reproduction to their bug reports.

Tagging for review 
@cpreston321 / @Tahul 