### PR TITLE
fix: `v-motion` directive variants leaking

### DIFF
--- a/src/directive/index.ts
+++ b/src/directive/index.ts
@@ -7,7 +7,7 @@ import { useMotion } from '../useMotion'
 import { resolveVariants } from '../utils/directive'
 import { variantToStyle } from '../utils/transform'
 
-export function directive<T extends string>(variants: MotionVariants<T> = {}): Directive<HTMLElement | SVGElement> {
+export function directive<T extends string>(variants?: MotionVariants<T>): Directive<HTMLElement | SVGElement> {
   const register = (el: HTMLElement | SVGElement, binding: DirectiveBinding, node: VNode<any, HTMLElement | SVGElement, Record<string, any>>) => {
     // Get instance key if possible (binding value or element key in case of v-for's)
     const key = (binding.value && typeof binding.value === 'string' ? binding.value : node.key) as string
@@ -16,7 +16,7 @@ export function directive<T extends string>(variants: MotionVariants<T> = {}): D
     if (key && motionState[key]) motionState[key].stop()
 
     // Initialize variants with argument
-    const variantsRef = ref(variants) as Ref<MotionVariants<T>>
+    const variantsRef = ref(variants || {}) as Ref<MotionVariants<T>>
 
     // Set variants from v-motion binding
     if (typeof binding.value === 'object') variantsRef.value = binding.value


### PR DESCRIPTION
You may have noticed the [demo page](https://vueuse-motion-demo.netlify.app/) is not working as expected, it seems only the initial motion variant is triggered. While testing #171 in the vite playground I noticed that simply adding en element using a visibility variant would make all motion elements disappear.

Using the Netlify deploy history of the demo page (https://app.netlify.com/sites/vueuse-motion-demo/deploys) I narrowed down when this broke to [this commit](https://github.com/vueuse/motion/commit/1c8d7bb8741cf91910d5ecb8209f07ce68f7cbef). I think that by changing the directive to accept a default value `{}` instead of undefined for variants, the same object is being reused for all `v-motion` usage, essentially each element using `v-motion` is overwriting/merging all the previous ones.

This partially fixes the demo page, but fixes what's probably a bigger bug. I'll have a separate PR to fix the demo page further soon. 