### PR TITLE
docs: fix demo reset and code preview

### DIFF
--- a/playgrounds/vite/src/components/CodeBlock.vue
+++ b/playgrounds/vite/src/components/CodeBlock.vue
@@ -25,17 +25,13 @@ function preRender(codeContent: string) {
 async function render() {
   if (!Prism.languages[props.language]) await import(/* @vite-ignore */ `prismjs/components/prism-${props.language}`)
 
-  nextTick(() => {
-    if (!(code?.value as any).value) return
+  await nextTick()
+  if (!code.value) return
 
-    const codeContent = props.text || code?.value?.innerText || ''
+  const codeContent = props.text || code?.value?.innerText || ''
 
-    if (code.value) {
-      code.value.textContent = preRender(codeContent)
-
-      Prism.highlightElement(code.value)
-    }
-  })
+  code.value.textContent = preRender(codeContent)
+  Prism.highlightElement(code.value)
 }
 
 watch(

--- a/playgrounds/vite/src/components/DemoBox.vue
+++ b/playgrounds/vite/src/components/DemoBox.vue
@@ -11,12 +11,13 @@ const emit = defineEmits(['replay'])
 
 const [visible, toggleVisible] = useToggle(true)
 
-function replay() {
+async function replay() {
   toggleVisible()
 
   emit('replay')
 
-  nextTick(toggleVisible)
+  await nextTick()
+  toggleVisible()
 }
 </script>
 


### PR DESCRIPTION
Fixes the reset button and code preview for the demo page. When this and #173 are merged the demo page should be fully functional again!