### PR TITLE
fix: types

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,27 +18,35 @@
     "v-motion",
     "popmotion-vue"
   ],
+  "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "require": "./dist/index.cjs",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
     },
     "./nuxt": {
-      "require": "./dist/nuxt.cjs",
-      "import": "./dist/nuxt.mjs"
+      "import": "./dist/nuxt.mjs",
+      "require": "./dist/nuxt.cjs"
     }
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist/**/*",
+    "dist",
     "LICENSE",
     "README.md"
   ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/*",
+        "./*"
+      ]
+    }
+  },
   "scripts": {
-    "build": "unbuild",
+    "build": "unbuild  && node ./scripts/fix-nuxt-build.mjs",
     "dev": "pnpm dev:vite",
     "release": "release-it",
     "lint": "eslint --ext .js,.vue,.ts,.tsx .",

--- a/scripts/fix-nuxt-build.mjs
+++ b/scripts/fix-nuxt-build.mjs
@@ -1,8 +1,8 @@
 import { readFile, writeFile } from 'node:fs/promises'
 
-async function pathNuxtCJS() {
+async function patchNuxtCJS() {
   const content = await readFile('dist/nuxt.cjs', 'utf-8')
   await writeFile('dist/nuxt.cjs', content.replace('module.exports = module$1;', 'exports.default = module$1;'))
 }
 
-pathNuxtCJS()
+patchNuxtCJS()

--- a/scripts/fix-nuxt-build.mjs
+++ b/scripts/fix-nuxt-build.mjs
@@ -1,0 +1,8 @@
+import { readFile, writeFile } from 'node:fs/promises'
+
+async function pathNuxtCJS() {
+  const content = await readFile('dist/nuxt.cjs', 'utf-8')
+  await writeFile('dist/nuxt.cjs', content.replace('module.exports = module$1;', 'exports.default = module$1;'))
+}
+
+pathNuxtCJS()


### PR DESCRIPTION
Current types are broken:
- motion node cjs
- nuxt types for node and node cjs

This PR also includes an mjs script to fix nuxt in cjs.

https://arethetypeswrong.github.io/?p=%40vueuse%2Fmotion%402.1.0

![imagen](https://github.com/vueuse/motion/assets/6311119/59d54ab4-3f78-493b-b1f2-126c69e27a53)

With this PR (included typesVersions to resolve types for Node):

![imagen](https://github.com/vueuse/motion/assets/6311119/938aa276-a068-41c9-b667-72df966e7d99)


closes #156