### PR TITLE
fix: prevent preset variants from being mutated

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -21,7 +21,7 @@ export const MotionPlugin: Plugin = {
         const preset = presets[key]
 
         // Register the preset `v-motion-${key}` directive
-        app.directive(`motion-${slugify(key)}`, directive(preset))
+        app.directive(`motion-${slugify(key)}`, directive(preset, true))
       }
     }
 
@@ -38,7 +38,7 @@ export const MotionPlugin: Plugin = {
         }
 
         // Register the custom `v-motion-${key}` directive
-        app.directive(`motion-${key}`, directive(variants))
+        app.directive(`motion-${key}`, directive(variants, true))
       }
     }
   },


### PR DESCRIPTION
<!--- ☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue
* #74 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #74 

This changes the way directive presets are handled, the underlying issue is similar to the one solved in https://github.com/vueuse/motion/pull/173, the preset variants are passed and reused and mutated down the line which is most noticeable in situations such as https://github.com/vueuse/motion/issues/74#issuecomment-1721145546.

To prevent this fix from influencing users variants (I suppose there are use cases where mutating a single motion is desired) I tried to only apply this change to directive presets.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.