### PR TITLE
fix: return to previous state after hovered event variant

### DIFF
--- a/src/features/eventListeners.ts
+++ b/src/features/eventListeners.ts
@@ -12,7 +12,7 @@ export function registerEventListeners<T extends string, V extends MotionVariant
   const focused = ref(false)
 
   const mutableKeys = computed(() => {
-    let result: string[] = []
+    let result: string[] = [...Object.keys(state.value || {})]
 
     if (!_variants) return result
 
@@ -26,7 +26,7 @@ export function registerEventListeners<T extends string, V extends MotionVariant
   })
 
   const computedProperties = computed(() => {
-    const result = {}
+    const result: Partial<V> = {}
 
     Object.assign(result, state.value)
 
@@ -37,7 +37,6 @@ export function registerEventListeners<T extends string, V extends MotionVariant
     if (focused.value && _variants.focused) Object.assign(result, _variants.focused)
 
     for (const key in result) {
-      // @ts-expect-error - Fix errors later for typescript 5
       if (!mutableKeys.value.includes(key)) delete result[key]
     }
 

--- a/src/features/lifeCycleHooks.ts
+++ b/src/features/lifeCycleHooks.ts
@@ -11,7 +11,14 @@ export function registerLifeCycleHooks<T extends string, V extends MotionVariant
       if (!_variants) return
 
       // Set initial before the element is mounted
-      if (_variants.initial) set('initial')
+      if (_variants.initial) {
+        // Set initial variant properties immediately, skipping transitions
+        set('initial')
+
+        // Set variant to sync `state` which is used to undo event variant transitions
+        // NOTE: This triggers an (instant) animation even though properties have already been applied
+        variant.value = 'initial'
+      }
 
       // Lifecycle hooks bindings
       if (_variants.enter) variant.value = 'enter'


### PR DESCRIPTION
<!--- ☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue
* #63 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #63 

The event variants use `state` as the variant to return to but the current variant is never set to `initial`, I'm assuming this was done to avoid triggering transitions?

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.