### PR TITLE
fix: transition `onComplete` triggers after each property animation

### DIFF
--- a/src/features/eventListeners.ts
+++ b/src/features/eventListeners.ts
@@ -83,6 +83,8 @@ export function registerEventListeners<T extends string, V extends MotionVariant
     useEventListener(target as any, 'blur', () => (focused.value = false))
   }
 
-  // Watch local computed variant, apply it dynamically
-  watch(computedProperties, apply)
+  // Watch event states, apply it computed properties
+  watch([hovered, tapped, focused], () => {
+    apply(computedProperties.value)
+  })
 }

--- a/src/utils/transition.ts
+++ b/src/utils/transition.ts
@@ -221,8 +221,6 @@ export function getAnimation(key: string, value: MotionValue, target: ResolvedVa
             if (valueTransition.onUpdate) valueTransition.onUpdate(v)
           },
           onComplete: () => {
-            if (transition.onComplete) transition.onComplete()
-
             if (onComplete) onComplete()
 
             if (complete) complete()
@@ -235,8 +233,6 @@ export function getAnimation(key: string, value: MotionValue, target: ResolvedVa
    */
   function set(complete?: () => void): StopAnimation {
     value.set(target)
-
-    if (transition.onComplete) transition.onComplete()
 
     if (onComplete) onComplete()
 

--- a/tests/components.spec.ts
+++ b/tests/components.spec.ts
@@ -32,7 +32,7 @@ describe.each([
     expect(el.style.opacity).toEqual('0')
     expect(el.style.transform).toEqual('translate3d(-100px,0px,0px)')
 
-    await waitForMockCalls(onComplete, 2)
+    await waitForMockCalls(onComplete)
 
     // Renders enter variant
     expect(el.style.opacity).toEqual('1')
@@ -56,16 +56,16 @@ describe.each([
     expect(el.style.color).toEqual('red')
     expect(el.style.transform).toEqual('translate3d(0px,100px,0px)')
 
-    // trigger mock intersection
+    // Trigger mock intersection
     intersect(el, true)
-    await waitForMockCalls(onComplete, 4)
+    await waitForMockCalls(onComplete)
 
     expect(el.style.color).toEqual('green')
     expect(el.style.transform).toEqual('translateZ(0px)')
 
-    // trigger mock intersection
+    // Trigger mock intersection
     intersect(el, false)
-    await waitForMockCalls(onComplete, 3)
+    await waitForMockCalls(onComplete)
 
     expect(el.style.color).toEqual('red')
     expect(el.style.transform).toEqual('translate3d(0px,100px,0px)')

--- a/tests/utils/index.ts
+++ b/tests/utils/index.ts
@@ -1,0 +1,27 @@
+import { type Mock, vi } from 'vitest'
+import { h } from 'vue'
+import { MotionComponent } from '../../src/components'
+
+export function useCompletionFn() {
+  return vi.fn(() => {})
+}
+
+// Get component using either `v-motion` directive or `<Motion>` component
+export function getTestComponent(t: string) {
+  if (t === 'directive') {
+    return { template: `<div v-motion>Hello world</div>` }
+  }
+
+  return { render: () => h(MotionComponent) }
+}
+
+// Waits until mock has been called and resets the call count
+export async function waitForMockCalls(fn: Mock, calls = 1, options: Parameters<typeof vi.waitUntil>['1'] = { interval: 10 }) {
+  try {
+    await vi.waitUntil(() => fn.mock.calls.length === calls, options)
+    fn.mockReset()
+  } catch (e) {
+    console.error(`Waited for ${calls} calls but failed at ${fn.mock.calls.length} calls.`)
+    throw e
+  }
+}

--- a/tests/utils/index.ts
+++ b/tests/utils/index.ts
@@ -20,8 +20,15 @@ export async function waitForMockCalls(fn: Mock, calls = 1, options: Parameters<
   try {
     await vi.waitUntil(() => fn.mock.calls.length === calls, options)
     fn.mockReset()
-  } catch (e) {
-    console.error(`Waited for ${calls} calls but failed at ${fn.mock.calls.length} calls.`)
-    throw e
+  } catch (err) {
+    // This ensures the vitest error log shows where this helper is called instead of the helper internals
+    if (err instanceof Error) {
+      err.message += ` Waited for ${calls} call(s) but failed at ${fn.mock.calls.length} call(s).`
+
+      const arr = err.stack?.split('\n')
+      arr?.splice(0, 3)
+      err.stack = arr?.join('\n') ?? undefined
+    }
+    throw err
   }
 }

--- a/tests/utils/intersectionObserver.ts
+++ b/tests/utils/intersectionObserver.ts
@@ -1,0 +1,51 @@
+// adapted from https://github.com/thebuilder/react-intersection-observer/blob/d35365990136bfbc99ce112270e5ff232cf45f7f/src/test-helper.ts
+// and https://jaketrent.com/post/test-intersection-observer-react/
+import { afterEach, beforeEach, vi } from 'vitest'
+
+const observerMap = new Map()
+const instanceMap = new Map()
+
+beforeEach(() => {
+  // @ts-expect-error mocked
+  window.IntersectionObserver = vi.fn((cb, options = {}) => {
+    const instance = {
+      thresholds: Array.isArray(options.threshold) ? options.threshold : [options.threshold],
+      root: options.root,
+      rootMargin: options.rootMargin,
+      observe: vi.fn((element: Element) => {
+        instanceMap.set(element, instance)
+        observerMap.set(element, cb)
+      }),
+      unobserve: vi.fn((element: Element) => {
+        instanceMap.delete(element)
+        observerMap.delete(element)
+      }),
+      disconnect: vi.fn(),
+    }
+    return instance
+  })
+})
+
+afterEach(() => {
+  // @ts-expect-error mocked
+  window.IntersectionObserver.mockReset()
+  instanceMap.clear()
+  observerMap.clear()
+})
+
+export function intersect(element: Element, isIntersecting: boolean) {
+  const cb = observerMap.get(element)
+  if (cb) {
+    cb([
+      {
+        isIntersecting,
+        target: element,
+        intersectionRatio: isIntersecting ? 1 : -1,
+      },
+    ])
+  }
+}
+
+export function getObserverOf(element: Element): IntersectionObserver {
+  return instanceMap.get(element)
+}


### PR DESCRIPTION
<!--- ☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue
* #188 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
During work on #188 I ran into two issues which made it difficult to test variants using the transition `onComplete` function:
* `onComplete` is called after every variant property animation completion
* When the event variants feature is enabled, variant animations are triggered twice (instantly)

This PR expands on #188 by fixing those issues (so that PR description still applies), I created this separate PR because it touches on more than just the tests.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.