### PR TITLE
fix: leaving hovered state when pointer hovers child element

### DIFF
--- a/src/features/eventListeners.ts
+++ b/src/features/eventListeners.ts
@@ -50,10 +50,6 @@ export function registerEventListeners<T extends string, V extends MotionVariant
       hovered.value = false
       tapped.value = false
     })
-    useEventListener(target as any, 'mouseout', () => {
-      hovered.value = false
-      tapped.value = false
-    })
   }
 
   // Tapped

--- a/tests/components.spec.ts
+++ b/tests/components.spec.ts
@@ -120,9 +120,16 @@ describe.each([
 
     expect(el.style.transform).toEqual('scale(1.2) translateZ(0px)')
 
-    // Should return to initial
+    // Should do nothing on 'mouseout'
+    await wrapper.trigger('mouseout')
+    // TODO: figure out a better way to test if a variant is not triggered than timeouts
+    await nextTick()
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+    await waitForMockCalls(onComplete, 0)
+
+    // Should return to initial, 'mouseleave' triggers when pointer left element and all descendants
     await wrapper.trigger('mouseleave')
-    await waitForMockCalls(onComplete)
+    await waitForMockCalls(onComplete, 1)
 
     expect(el.style.transform).toEqual('scale(1) translateZ(0px)')
   })


### PR DESCRIPTION
<!--- ☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue
* #191
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #191

As we are using the [`'mouseout'`](https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseout_event) event to detect whether a motion should leave the hovered state it would also get triggered when hovering a child element.

From what I can tell the [`'mouseleave'`](https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseleave_event) event should be sufficient for this, are there possible use cases for using `'mouseout'`?

I'm not quite sure if the test I added will be stable (not flaky) as it uses timeouts to check if the variant/state remains unchanged, this may need to be improved.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.