### PR TITLE
fix: `x`, `y`, `z` not accepting relative units

### DIFF
--- a/src/reactiveTransform.ts
+++ b/src/reactiveTransform.ts
@@ -34,7 +34,17 @@ export function reactiveTransform(props: TransformProperties = {}, enableHardwar
       // Use translate3d by default has a better GPU optimization
       // And corrects scaling discrete behaviors
       if (enableHardwareAcceleration && (newVal.x || newVal.y || newVal.z)) {
-        const str = [newVal.x || 0, newVal.y || 0, newVal.z || 0].map(px.transform as any).join(',')
+        const str = [newVal.x || 0, newVal.y || 0, newVal.z || 0]
+          .map((val) => {
+            // Convert plain numbers to `px`
+            if(typeof val === 'number') {
+              return px.transform!(val)
+            }
+
+            // Use non-number values as is (allows `%`, `em`, ...)
+            return val
+          })
+          .join(',')
 
         result += `translate3d(${str}) `
 

--- a/src/reactiveTransform.ts
+++ b/src/reactiveTransform.ts
@@ -35,15 +35,7 @@ export function reactiveTransform(props: TransformProperties = {}, enableHardwar
       // And corrects scaling discrete behaviors
       if (enableHardwareAcceleration && (newVal.x || newVal.y || newVal.z)) {
         const str = [newVal.x || 0, newVal.y || 0, newVal.z || 0]
-          .map((val) => {
-            // Convert plain numbers to `px`
-            if (typeof val === 'number') {
-              return px.transform!(val)
-            }
-
-            // Use non-number values as is (allows `%`, `em`, ...)
-            return val
-          })
+          .map(val => getValueAsType(val, px))
           .join(',')
 
         result += `translate3d(${str}) `

--- a/src/reactiveTransform.ts
+++ b/src/reactiveTransform.ts
@@ -37,7 +37,7 @@ export function reactiveTransform(props: TransformProperties = {}, enableHardwar
         const str = [newVal.x || 0, newVal.y || 0, newVal.z || 0]
           .map((val) => {
             // Convert plain numbers to `px`
-            if(typeof val === 'number') {
+            if (typeof val === 'number') {
               return px.transform!(val)
             }
 

--- a/src/utils/style.ts
+++ b/src/utils/style.ts
@@ -113,7 +113,7 @@ export const valueTypes: ValueTypeMap = {
 export const getValueType = (key: string) => valueTypes[key]
 
 /**
- * Transform the value using its value type, or return the value.
+ * Transform the value using its value type if value is a `number`, otherwise return the value.
  *
  * @param value
  * @param type

--- a/tests/reactiveTransform.spec.ts
+++ b/tests/reactiveTransform.spec.ts
@@ -51,4 +51,15 @@ describe('reactiveTransform', () => {
 
     expect(transform.value).toBe('rotateX(90deg) translateZ(0px)')
   })
+
+  it('accepts relative units when hardware acceleration is enabled', () => {
+    const { transform } = reactiveTransform(
+      {
+        y: '100%',
+      },
+      true,
+    )
+
+    expect(transform.value).toBe('translate3d(0px,100%,0px)')
+  })
 })


### PR DESCRIPTION
<!--- ☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue
* #24 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #24 

This changes the parsing of `x`, `y` and `z` properties to also allow other units (these are not validated) while keeping the default of transforming plain numbers to `px` units.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
