### PR TITLE
fix: <MotionGroup> not applying motion to child nodes in v-for

### DIFF
--- a/src/components/Motion.ts
+++ b/src/components/Motion.ts
@@ -6,6 +6,7 @@ import { variantToStyle } from '../utils/transform'
 import { MotionComponentProps, setupMotionComponent } from '../utils/component'
 
 export default defineComponent({
+  name: 'Motion',
   props: {
     ...MotionComponentProps,
     is: {

--- a/src/components/MotionGroup.ts
+++ b/src/components/MotionGroup.ts
@@ -1,11 +1,12 @@
 import type { PropType, VNode } from 'vue'
 import type { Component } from '@nuxt/schema'
 
-import { defineComponent, h, useSlots } from 'vue'
+import { Fragment, defineComponent, h, useSlots } from 'vue'
 import { variantToStyle } from '../utils/transform'
 import { MotionComponentProps, setupMotionComponent } from '../utils/component'
 
 export default defineComponent({
+  name: 'MotionGroup',
   props: {
     ...MotionComponentProps,
     is: {
@@ -24,7 +25,27 @@ export default defineComponent({
 
       // Set node style on slots and register to `instances` on mount
       for (let i = 0; i < nodes.length; i++) {
-        setNodeInstance(nodes[i], i, style)
+        const n = nodes[i]
+
+        // Recursively assign fragment child nodes
+        if (n.type === Fragment && Array.isArray(n.children)) {
+          n.children.forEach(function setChildInstance(child, index) {
+            if (child == null)
+              return
+
+            if (Array.isArray(child)) {
+              setChildInstance(child, index)
+              return
+            }
+
+            if (typeof child === 'object') {
+              setNodeInstance(child, index, style)
+            }
+          })
+        }
+        else {
+          setNodeInstance(n, i, style)
+        }
       }
 
       // Wrap child nodes in component if `props.is` is passed

--- a/tests/components.spec.ts
+++ b/tests/components.spec.ts
@@ -1,7 +1,8 @@
 import { config, mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
-import { nextTick } from 'vue'
+import { h, nextTick } from 'vue'
 import { MotionPlugin } from '../src'
+import MotionGroup from '../src/components/MotionGroup'
 import { intersect } from './utils/intersectionObserver'
 import { getTestComponent, useCompletionFn, waitForMockCalls } from './utils'
 
@@ -132,5 +133,40 @@ describe.each([
     await waitForMockCalls(onComplete, 1)
 
     expect(el.style.transform).toEqual('scale(1) translateZ(0px)')
+  })
+})
+
+describe('`<MotionGroup>` component', async () => {
+  it('child node can overwrite helpers', async () => {
+    const wrapper = mount({
+      render: () =>
+        h(
+          MotionGroup,
+          {
+            initial: { opacity: 0 },
+            enter: {
+              opacity: 0.5,
+              transition: { ease: 'linear', delay: 100000 },
+            },
+          },
+          [
+            h('div', { id: 1, key: 1, delay: 0 }),
+            h('div', { id: 2, key: 2 }),
+            h('div', { id: 3, key: 3 }),
+          ],
+        ),
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 100))
+
+    // First div should have finished `enter` variant
+    expect(
+      (wrapper.find('div#1').element as HTMLDivElement).style?.opacity,
+    ).toEqual('0.5')
+
+    // Second div should not have started yet
+    expect(
+      (wrapper.find('div#2').element as HTMLDivElement).style?.opacity,
+    ).toEqual('0')
   })
 })


### PR DESCRIPTION
<!--- ☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Motions were not being applied to child nodes of `<MotionGroup>` when used in a for loop, this checks if a child node is a `Fragment` and applies settings to each child node.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
