### PR TITLE
fix(component): preserve variant style on rerender

### DIFF
--- a/src/utils/component.ts
+++ b/src/utils/component.ts
@@ -17,6 +17,7 @@ import type {
   Variant,
 } from '../types/variants'
 import { useMotion } from '../useMotion'
+import { variantToStyle } from './transform'
 
 /**
  * Type guard, checks if passed string is an existing preset
@@ -226,6 +227,18 @@ export function setupMotionComponent(
         el as any,
         elementMotionConfig,
       )
+    }
+
+    /**
+     * Vue reapplies all styles every render, include style properties and calculated initially styles get reapplied every render.
+     * To prevent this, reapply the current motion state styles in vnode updated lifecycle
+     */
+    node.props.onVnodeUpdated = ({ el }) => {
+      const styles = variantToStyle(instances[index].state as Variant);
+
+      for (const [key, val] of Object.entries(styles)) {
+        (el as any).style[key] = val
+      }
     }
 
     return node

--- a/src/utils/component.ts
+++ b/src/utils/component.ts
@@ -234,7 +234,7 @@ export function setupMotionComponent(
      * To prevent this, reapply the current motion state styles in vnode updated lifecycle
      */
     node.props.onVnodeUpdated = ({ el }) => {
-      const styles = variantToStyle(instances[index].state as Variant);
+      const styles = variantToStyle(instances[index].state as Variant)
 
       for (const [key, val] of Object.entries(styles)) {
         (el as any).style[key] = val

--- a/tests/components.spec.ts
+++ b/tests/components.spec.ts
@@ -1,7 +1,7 @@
 import { config, mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
-import { h, nextTick } from 'vue'
-import { MotionPlugin } from '../src'
+import { h, nextTick, ref } from 'vue'
+import { MotionComponent, MotionPlugin } from '../src'
 import MotionGroup from '../src/components/MotionGroup'
 import { intersect } from './utils/intersectionObserver'
 import { getTestComponent, useCompletionFn, waitForMockCalls } from './utils'
@@ -133,6 +133,34 @@ describe.each([
     await waitForMockCalls(onComplete, 1)
 
     expect(el.style.transform).toEqual('scale(1) translateZ(0px)')
+  })
+
+  it('#202 - preserve variant style on rerender', async () => {
+    const counter = ref(0)
+
+    const wrapper = mount(
+      { render: () => h(MotionComponent, null, () => counter.value) },
+      {
+        props: {
+          initial: { scale: 1 },
+          enter: { scale: 2 },
+          duration: 10,
+        },
+      },
+    )
+
+    const el = wrapper.element as HTMLDivElement
+    await nextTick()
+
+    // Renders enter
+    expect(el.style.transform).toEqual('scale(2) translateZ(0px)')
+
+    // Trigger rerender by updating slot variable
+    counter.value++
+    await nextTick()
+
+    // Variant style is preserved after rerender/update
+    expect(el.style.transform).toEqual('scale(2) translateZ(0px)')
   })
 })
 

--- a/tests/components.spec.ts
+++ b/tests/components.spec.ts
@@ -10,8 +10,8 @@ import { getTestComponent, useCompletionFn, waitForMockCalls } from './utils'
 config.global.plugins.push(MotionPlugin)
 
 describe.each([
-  { t: 'directive', name: '`v-motion` directive' },
-  { t: 'component', name: '`<Motion>` component' },
+  { t: 'directive', name: '`v-motion` directive (shared tests)' },
+  { t: 'component', name: '`<Motion>` component (shared tests)' },
 ])(`$name`, async ({ t }) => {
   const TestComponent = getTestComponent(t)
 
@@ -134,7 +134,9 @@ describe.each([
 
     expect(el.style.transform).toEqual('scale(1) translateZ(0px)')
   })
+})
 
+describe('`<Motion>` component', async () => {
   it('#202 - preserve variant style on rerender', async () => {
     const counter = ref(0)
 


### PR DESCRIPTION
### 🔗 Linked issue

[Issue #202](https://github.com/vueuse/motion/issues/202)

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
