### PR TITLE
fix: motion component not using and merging custom presets

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -5,17 +5,12 @@ import * as presets from '../presets'
 import { directive } from '../directive'
 import { slugify } from '../utils/slugify'
 import { MotionComponent, MotionGroupComponent } from '../components'
+import { CUSTOM_PRESETS } from '../utils/keys'
 
 export const MotionPlugin: Plugin = {
   install(app, options: MotionPluginOptions<string>) {
     // Register default `v-motion` directive
     app.directive('motion', directive())
-
-    // Register <Motion> component
-    app.component('Motion', MotionComponent)
-
-    // Register <MotionGroup> component
-    app.component('MotionGroup', MotionGroupComponent)
 
     // Register presets
     if (!options || (options && !options.excludePresets)) {
@@ -44,7 +39,15 @@ export const MotionPlugin: Plugin = {
         // Register the custom `v-motion-${key}` directive
         app.directive(`motion-${key}`, directive(variants, true))
       }
+
+      app.provide(CUSTOM_PRESETS, options.directives)
     }
+
+    // Register <Motion> component
+    app.component('Motion', MotionComponent)
+
+    // Register <MotionGroup> component
+    app.component('MotionGroup', MotionGroupComponent)
   },
 }
 

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -39,9 +39,9 @@ export const MotionPlugin: Plugin = {
         // Register the custom `v-motion-${key}` directive
         app.directive(`motion-${key}`, directive(variants, true))
       }
-
-      app.provide(CUSTOM_PRESETS, options.directives)
     }
+
+    app.provide(CUSTOM_PRESETS, options?.directives)
 
     // Register <Motion> component
     app.component('Motion', MotionComponent)

--- a/src/utils/keys.ts
+++ b/src/utils/keys.ts
@@ -1,0 +1,3 @@
+export const CUSTOM_PRESETS = Symbol(
+  import.meta.dev ? 'motionCustomPresets' : '',
+)

--- a/tests/components.spec.ts
+++ b/tests/components.spec.ts
@@ -7,7 +7,17 @@ import { intersect } from './utils/intersectionObserver'
 import { getTestComponent, useCompletionFn, waitForMockCalls } from './utils'
 
 // Register plugin
-config.global.plugins.push(MotionPlugin)
+config.global.plugins.push([
+  MotionPlugin,
+  {
+    directives: {
+      'custom-preset': {
+        initial: { scale: 1, y: 50 },
+        hovered: { scale: 1.2, y: 0 },
+      },
+    },
+  },
+])
 
 describe.each([
   { t: 'directive', name: '`v-motion` directive (shared tests)' },
@@ -137,6 +147,32 @@ describe.each([
 })
 
 describe('`<Motion>` component', async () => {
+  it('uses and merges custom presets', async () => {
+    const wrapper = mount(
+      { render: () => h(MotionComponent) },
+      {
+        props: {
+          preset: 'custom-preset',
+          hovered: { y: 100 },
+          duration: 10,
+        },
+      },
+    )
+
+    const el = wrapper.element as HTMLDivElement
+    await nextTick()
+
+    // Renders initial
+    expect(el.style.transform).toMatchInlineSnapshot(`"translate3d(0px,50px,0px) scale(1)"`)
+
+    // Trigger hovered
+    await wrapper.trigger('mouseenter')
+    await new Promise(resolve => setTimeout(resolve, 100))
+
+    // `custom-preset` sets scale: 1.2 and `hovered` prop sets y: 100
+    expect(el.style.transform).toMatchInlineSnapshot(`"translate3d(0px,100px,0px) scale(1.2)"`)
+  })
+
   it('#202 - preserve variant style on rerender', async () => {
     const counter = ref(0)
 


### PR DESCRIPTION
<!--- ☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue
* #201 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #201 

This changes the Motion components to also use configured custom directives (should we consider renaming this to presets?) and should also allow merging/overriding by passing variant props as you normally do.

Does this make the components feature complete with the directive implementation? If not, let me know what's missing and I'll see to making it work 😄 

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
