### PR TITLE
docs: add click for preset previews

### DIFF
--- a/docs/components/content/PresetSection.vue
+++ b/docs/components/content/PresetSection.vue
@@ -71,7 +71,7 @@ async function replay() {
         <button class="absolute right-4 top-4" @click="replay">
           <Icon ref="replayButton" name="heroicons-outline:refresh" class="h-6 w-6" />
         </button>
-        <div ref="demoElement" class="demoElement">
+        <div ref="demoElement" class="demoElement" @click="replay">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1000">
             <path
               class="a"


### PR DESCRIPTION
<!--- ☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
close: #115 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Bind the preview component to the click event.
As for hover, it seems a bit messy to add it, so I haven't added it yet.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
