### PR TITLE
fix: augment `vue` rather than `@vue/runtime-core`

### DIFF
--- a/src/types/instance.ts
+++ b/src/types/instance.ts
@@ -74,13 +74,13 @@ export interface SpringControls {
 
 export type MotionInstanceBindings<T extends string, V extends MotionVariants<T>> = Record<string, MotionInstance<T, V>>
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     $motions?: MotionInstanceBindings<any, any>
   }
 }
 
-declare module '@vue/runtime-dom' {
+declare module 'vue' {
   interface HTMLAttributes {
     variants?: MotionVariants<any>
     // Initial variant

--- a/src/types/instance.ts
+++ b/src/types/instance.ts
@@ -80,7 +80,7 @@ declare module 'vue' {
   }
 }
 
-declare module 'vue' {
+declare module '@vue/runtime-dom' {
   interface HTMLAttributes {
     variants?: MotionVariants<any>
     // Initial variant


### PR DESCRIPTION
<!--- ☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In line with https://github.com/vuejs/router/pull/2295 and https://github.com/nuxt/nuxt/pull/28542, this moves to augment `vue` rather than `@vue/runtime` core.

This is now officially recommended [in the docs](https://vuejs.org/api/utility-types.html#componentcustomproperties) and it _must_ be done by all libraries or it will break types for _other_ libraries.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
