### PR TITLE
fix: use `toRaw` when cloning proxy object

### DIFF
--- a/src/directive/index.ts
+++ b/src/directive/index.ts
@@ -1,6 +1,6 @@
 import type { Directive, DirectiveBinding, Ref, VNode } from 'vue'
 import defu from 'defu'
-import { ref, unref } from 'vue'
+import { ref, toRaw, unref } from 'vue'
 import { motionState } from '../features/state'
 import type { MotionInstance, MotionVariants } from '../types'
 import { useMotion } from '../useMotion'
@@ -21,7 +21,7 @@ export function directive<T extends string>(
       motionState[key].stop()
 
     // We deep copy presets to prevent global mutation
-    const variantsObject = isPreset ? structuredClone(variants || {}) : variants || {}
+    const variantsObject = isPreset ? structuredClone(toRaw(variants) || {}) : variants || {}
 
     // Initialize variants with argument
     const variantsRef = ref(variantsObject) as Ref<MotionVariants<T>>


### PR DESCRIPTION
<!--- ☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

Nuxt 3 error with custom directive https://github.com/vueuse/motion/issues/218

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves https://github.com/vueuse/motion/issues/218

This changes ensure that the custom directive object are not Vue's reactive object to allow the `StructuredClone` function to as expected.

Perhaps this should have always been included?


### 📝 Checklist


- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
