### PR TITLE
feat(component): wrap `leave` variant internally

### DIFF
--- a/src/components/Motion.ts
+++ b/src/components/Motion.ts
@@ -1,7 +1,7 @@
 import type { Component } from '@nuxt/schema'
 import type { PropType } from 'vue'
 
-import { defineComponent, h, useSlots } from 'vue'
+import { Transition, defineComponent, h, useAttrs, useSlots } from 'vue'
 import { variantToStyle } from '../utils/transform'
 import { MotionComponentProps, setupMotionComponent } from '../utils/component'
 
@@ -13,17 +13,38 @@ export default defineComponent({
       type: [String, Object] as PropType<string | Component>,
       default: 'div',
     },
+    // TODO: figure out if this is possible using `v-if`, otherwise find better prop name
+    present: {
+      type: Boolean,
+      default: true,
+    },
   },
+  inheritAttrs: false,
   setup(props) {
     const slots = useSlots()
 
     const { motionConfig, setNodeInstance } = setupMotionComponent(props)
+    const attrs = useAttrs()
 
     return () => {
       const style = variantToStyle(motionConfig.value.initial || {})
-      const node = h(props.is, undefined, slots)
+      const node = h(props.is, attrs, slots)
 
-      setNodeInstance(node, 0, style)
+      const instance = setNodeInstance(node, 0, style)
+
+      // Wrap component in Transition if leave variant is set
+      if (props.leave) {
+        const wrapper = h(
+          Transition,
+          {
+            css: false,
+            onLeave: (_: any, done: any) => instance.leave(done),
+          },
+          () => [props.present && node],
+        )
+
+        return wrapper
+      }
 
       return node
     }

--- a/src/components/Motion.ts
+++ b/src/components/Motion.ts
@@ -23,14 +23,15 @@ export default defineComponent({
   setup(props) {
     const slots = useSlots()
 
-    const { motionConfig, setNodeInstance } = setupMotionComponent(props)
-    const attrs = useAttrs()
+    const { instances, motionConfig, setNodeInstance }
+      = setupMotionComponent(props)
 
     return () => {
+      const attrs = useAttrs()
       const style = variantToStyle(motionConfig.value.initial || {})
       const node = h(props.is, attrs, slots)
 
-      const instance = setNodeInstance(node, 0, style)
+      setNodeInstance(node, 0, style)
 
       // Wrap component in Transition if leave variant is set
       if (props.leave) {
@@ -38,7 +39,7 @@ export default defineComponent({
           Transition,
           {
             css: false,
-            onLeave: (_: any, done: any) => instance.leave(done),
+            onLeave: (_: any, done: any) => instances[0].leave(done),
           },
           () => [props.present && node],
         )

--- a/src/utils/component.ts
+++ b/src/utils/component.ts
@@ -257,11 +257,11 @@ export function setupMotionComponent(
       const styles = variantToStyle(instances[index].state as Variant)
 
       for (const [key, val] of Object.entries(styles)) {
-        (el as any).style[key] = val
+        ;(el as any).style[key] = val
       }
     }
 
-    return node
+    return instances[index]
   }
 
   return {

--- a/src/utils/component.ts
+++ b/src/utils/component.ts
@@ -261,10 +261,11 @@ export function setupMotionComponent(
       }
     }
 
-    return instances[index]
+    return node
   }
 
   return {
+    instances,
     motionConfig,
     setNodeInstance,
   }


### PR DESCRIPTION
<!--- ☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue
* #83
* #142
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This conditionally wraps the motion component in a transition if a leave variant is provided, this should remove the need for users the do this manually. I'm not entirely sure what implications this has on passed attributes or other nested component/element behaviors, we could consider putting this behind a config flag if it causes issues.

In the current implementation it adds a `present` prop that serves the same purpose as `v-if`, it would be ideal if we could make the `v-if` directive apply on the wrapped/nested element instead.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
