### PR TITLE
refactor: import functions and types directly from `vue`

### DIFF
--- a/src/types/instance.ts
+++ b/src/types/instance.ts
@@ -1,5 +1,5 @@
-import type { MaybeRef, VueInstance } from '@vueuse/core'
-import type { Ref, UnwrapRef } from 'vue'
+import type { VueInstance } from '@vueuse/core'
+import type { MaybeRef, Ref, UnwrapRef } from 'vue'
 import type { MotionProperties, MotionVariants, Variant } from './variants'
 
 export type PermissiveTarget = VueInstance | MotionTarget

--- a/src/useElementStyle.ts
+++ b/src/useElementStyle.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core'
-import type { Reactive } from 'vue'
+import type { MaybeRef, Reactive } from 'vue'
 import { watch } from 'vue'
 import { reactiveStyle } from './reactiveStyle'
 import type { MotionTarget, PermissiveTarget, StyleProperties } from './types'

--- a/src/useElementTransform.ts
+++ b/src/useElementTransform.ts
@@ -1,6 +1,5 @@
-import type { MaybeRef } from '@vueuse/core'
 import { watch } from 'vue'
-import type { Reactive } from 'vue'
+import type { MaybeRef, Reactive } from 'vue'
 import { reactiveTransform } from './reactiveTransform'
 import type { MotionTarget, PermissiveTarget, TransformProperties } from './types'
 import { usePermissiveTarget } from './usePermissiveTarget'

--- a/src/useMotion.ts
+++ b/src/useMotion.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core'
+import type { MaybeRef } from 'vue'
 import type { MotionInstance, MotionVariants, PermissiveTarget, UseMotionOptions } from './types'
 import { useMotionControls } from './useMotionControls'
 import { useMotionFeatures } from './useMotionFeatures'

--- a/src/useMotionControls.ts
+++ b/src/useMotionControls.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/core'
+import type { MaybeRef } from 'vue'
 import { isObject } from '@vueuse/core'
 import { ref, unref, watch } from 'vue'
 import type { MotionControls, MotionProperties, MotionTransitions, MotionVariants, Variant } from './types'

--- a/src/useMotionProperties.ts
+++ b/src/useMotionProperties.ts
@@ -1,6 +1,5 @@
-import type { MaybeRef } from '@vueuse/core'
 import { reactive, watch } from 'vue'
-import type { Reactive } from 'vue'
+import type { MaybeRef, Reactive } from 'vue'
 import type { MotionProperties, PermissiveTarget, StyleProperties, TransformProperties } from './types'
 import { useElementStyle } from './useElementStyle'
 import { useElementTransform } from './useElementTransform'

--- a/src/useMotionVariants.ts
+++ b/src/useMotionVariants.ts
@@ -1,5 +1,4 @@
-import type { MaybeRef } from '@vueuse/core'
-import type { Ref } from 'vue'
+import type { MaybeRef, Ref } from 'vue'
 import { computed, ref, unref } from 'vue'
 import type { MotionVariants, Variant } from './types'
 

--- a/src/usePermissiveTarget.ts
+++ b/src/usePermissiveTarget.ts
@@ -1,6 +1,6 @@
 import { watch } from 'vue'
 import { unrefElement } from '@vueuse/core'
-import type { MaybeRef } from '@vueuse/shared'
+import type { MaybeRef } from 'vue'
 import type { PermissiveTarget } from './types'
 
 export function usePermissiveTarget(target: MaybeRef<PermissiveTarget>, onTarget: (target: HTMLElement | SVGElement) => void) {

--- a/src/useReducedMotion.ts
+++ b/src/useReducedMotion.ts
@@ -1,4 +1,5 @@
-import { type Ref, computed } from 'vue'
+import { computed } from 'vue'
+import type { Ref } from 'vue'
 import { useMediaQuery } from '@vueuse/core'
 
 /**

--- a/src/useSpring.ts
+++ b/src/useSpring.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from '@vueuse/shared'
+import type { MaybeRef } from 'vue'
 import { animate } from 'popmotion'
 import type { MotionProperties, PermissiveMotionProperties, PermissiveTarget, Spring, SpringControls } from './types'
 import { useMotionValues } from './useMotionValues'

--- a/src/utils/element.ts
+++ b/src/utils/element.ts
@@ -1,8 +1,6 @@
-import type { Ref } from '@vue/reactivity'
-import { ref } from '@vue/reactivity'
-import { watch } from '@vue/runtime-core'
+import { ref, watch } from 'vue'
 import type { VueInstance } from '@vueuse/core'
-import type { MaybeRef } from '@vueuse/shared'
+import type { MaybeRef, Ref } from 'vue'
 import type { MotionTarget, PermissiveTarget } from '../types'
 
 export function resolveElement(target: MaybeRef<PermissiveTarget>): Ref<MotionTarget> {


### PR DESCRIPTION
<!--- ☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Prefer importing types and functions from `vue` instead of `@vueuse/` if possible.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
